### PR TITLE
split_at/4 mode discussion

### DIFF
--- a/prolog/list_util.pl
+++ b/prolog/list_util.pl
@@ -118,17 +118,18 @@ take(N, List, Front) :-
 %  Xs = Take, Take = [] ;
 %  Xs = Take, Take = [_G3810].
 %  ==
-split_at(N,Xs,Take,Rest) :-
-    split_at_(Xs,N,Take,Rest).
+split_at(N, Xs, Take, Rest) :-
+    (  maplist(var, [N,Take])
+    -> split_at_(Xs, N, Take, Rest)
+    ;  once(split_at_(Xs, N, Take, Rest))
+    ).
 
-split_at_(Rest, 0, [], Rest) :- !. % optimization
+split_at_(Rest, 0, [], Rest).
 split_at_([], N, [], []) :-
-    % cannot optimize here because (+, -, -, -) would be wrong,
-    % which could possibly be a useful generator.
-    N > 0.
+    when(ground(N), N > 0).
 split_at_([X|Xs], N, [X|Take], Rest) :-
-    N > 0,
-    succ(N0, N),
+    when(ground(N), N > 0),
+    when(ground(N0), succ(N0, N)),
     split_at_(Xs, N0, Take, Rest).
 
 

--- a/prolog/list_util.pl
+++ b/prolog/list_util.pl
@@ -37,6 +37,7 @@
           , xfy_list/3
           ]).
 :- use_module(library(apply_macros)).  % for faster maplist/2
+:- use_module(library(clpfd)).
 :- use_module(library(pairs), [group_pairs_by_key/2, map_list_to_pairs/3, pairs_values/2]).
 :- use_module(library(readutil), [read_line_to_string/2]).
 :- use_module(library(when), [when/2]).
@@ -126,10 +127,10 @@ split_at(N, Xs, Take, Rest) :-
 
 split_at_(Rest, 0, [], Rest).
 split_at_([], N, [], []) :-
-    when(ground(N), N > 0).
+    N #> 0.
 split_at_([X|Xs], N, [X|Take], Rest) :-
-    when(ground(N), N > 0),
-    when(ground(N0), succ(N0, N)),
+    N #> 0,
+    N #= N0 + 1,
     split_at_(Xs, N0, Take, Rest).
 
 

--- a/prolog/list_util.pl
+++ b/prolog/list_util.pl
@@ -119,7 +119,7 @@ take(N, List, Front) :-
 %  Xs = Take, Take = [_G3810].
 %  ==
 split_at(N, Xs, Take, Rest) :-
-    (  maplist(var, [N,Take])
+    (  var(N), var(Take)
     -> split_at_(Xs, N, Take, Rest)
     ;  once(split_at_(Xs, N, Take, Rest))
     ).

--- a/prolog/list_util.pl
+++ b/prolog/list_util.pl
@@ -119,19 +119,17 @@ take(N, List, Front) :-
 %  Xs = Take, Take = [] ;
 %  Xs = Take, Take = [_G3810].
 %  ==
-split_at(N, Xs, Take, Rest) :-
-    (  var(N), var(Take)
-    -> split_at_(Xs, N, Take, Rest)
-    ;  once(split_at_(Xs, N, Take, Rest))
-    ).
+split_at(N,Xs,Take,Rest) :-
+    TakeLength #=< N,
+    ( nonvar(Rest), Rest=[_|_] -> TakeLength=N; true ),
+    split_at_(Take,Rest,Xs,0,TakeLength),
+    ( TakeLength < N -> Rest=[]; !). % remove dangling choicepoint
 
-split_at_(Rest, 0, [], Rest).
-split_at_([], N, [], []) :-
-    N #> 0.
-split_at_([X|Xs], N, [X|Take], Rest) :-
-    N #> 0,
-    N #= N0 + 1,
-    split_at_(Xs, N0, Take, Rest).
+split_at_([X|Xs],Rest,[X|Ys],N0,N) :-
+    N1 #= N0 + 1,
+    N1 #=< N,
+    split_at_(Xs,Rest,Ys,N1,N).
+split_at_([],L,L,N,N).
 
 
 %% take_while(:Goal, +List1:list, -List2:list) is det.

--- a/t/split_at.pl
+++ b/t/split_at.pl
@@ -49,6 +49,6 @@ unbound_l_take_empty :-
   ).
 
 zero_unbound_l_take :-
-  split_at(0, L, Take, [a,b]),
-  L == [a,b],
-  Take == [].
+    split_at(0, L, Take, [a,b]),
+    L == [a,b],
+    Take == [].

--- a/t/split_at.pl
+++ b/t/split_at.pl
@@ -52,3 +52,40 @@ zero_unbound_l_take :-
     split_at(0, L, Take, [a,b]),
     L == [a,b],
     Take == [].
+
+blank_n :-
+    split_at(N, [1,2,3], [1], [2,3]),
+    N == 1.
+
+blank_n_and_list :-
+    split_at(N, List, [3,4,5], [6,7]),
+    N == 3,
+    List == [3,4,5,6,7].
+
+blank_n_and_list_empty_rest :-
+    split_at(N, List, [a,b,c], []),
+    N == 3,
+    List == [a,b,c].
+
+blank_n_and_list_and_rest :-
+    split_at(N, List, [3,4,5], Rest),
+    N == 3,
+    List = [3,4,5|Rest],
+    var(Rest).
+
+nondet_split_at :-
+    findall(
+        sol(N,Take,Rest),
+        split_at(N, [3,4,5], Take, Rest),
+        [S0,S1,S2,S3,S4]
+    ),
+    S0 == sol(0, [], [3,4,5]),
+    S1 == sol(1, [3], [4,5]),
+    S2 == sol(2, [3,4], [5]),
+    S3 == sol(3, [3,4,5], []),
+
+    % Matching N > 0
+    S4 = sol(N0, Take, R0),
+    Take == [3,4,5],
+    R0 == [],
+    var(N0).

--- a/t/take.pl
+++ b/t/take.pl
@@ -19,3 +19,26 @@ backward :-
 backward_huge :-
     take(300, L, [a,b]),
     L = [a,b].
+
+blank_n :-
+    take(N, [1,2,3], [1]),
+    N == 1.
+
+blank_n_and_list :-
+    take(N, List, [3,4,5]),
+    N == 3,
+    List = [3,4,5|Rest],
+    var(Rest).
+
+nondet_take :-
+    findall(N-Take, take(N, [3,4,5], Take), [N0-T0, N1-T1, N2-T2, N3-T3, V-T4]),
+    N0 == 0,
+    N1 == 1,
+    N2 == 2,
+    N3 == 3,
+    T0 == [],
+    T1 == [3],
+    T2 == [3,4],
+    T3 == [3,4,5],
+    T4 == [3,4,5],
+    var(V).


### PR DESCRIPTION
This pull request is only intended for discussion.  It should not be merged in its current state.

The first 4 commits are fine.  They implement the split_at/4 semantics defined by @eazar001 in #26.  If we decide those are the right semantics, we can just merge those commits and be done.

Commit b56cdfa707136253fb992f1183f8a2c53f9aaa8b is me playing with a slightly different implementation.  It's basically append/3 plus a `PrefixLength` argument that's calculated using clpfd.  Then I swapped the clauses of append/3 to force a search for "longest prefix first".  At this point the code supported all traditional modes for split_at/4 and take/3.

I don't really like this implementation, but it's helpful for experimenting with the main semantic question: Should `take(N,[a],[a])` yield `N=1` or `N=1;N=2;N=3;...` or `N in 1..sup`?

Any of `take(1,[a],[a])` or `take(3,[a],[a])` or `take(1_000,[a],[a])` would succeed.  Is it useful to produce all those values of `N` when `N` starts out unbound?

I don't have any more time to work on this today but wanted to dump my progress to this point.